### PR TITLE
Add '--allow-downgrades' to 'apt install' and change 'sudo su' to 'sudo ./'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@ $ wget https://raw.githubusercontent.com/averyfreeman/dotnet-sdk-5.0rc1-Ubuntu-2
 
 $ chmod + x install-dotnet-preview-groovy.sh
 
-$ sudo su
-
-# ./install-dotnet-preview-groovy.sh
-
-# exit
+$ sudo ./install-dotnet-preview-groovy.sh
 
 $ dotnet --info
 ```

--- a/install-dotnet-preview-groovy.sh
+++ b/install-dotnet-preview-groovy.sh
@@ -173,7 +173,7 @@ function install()
         rpm -ivh --replacepkgs $DOWNLOAD_DIR/$DOTNET_PACKAGE_DIR/*
     elif [ $PACKAGE_TYPE == "deb" ]
     then
-        apt install -y $DOWNLOAD_DIR/$DOTNET_PACKAGE_DIR/*
+        apt install -y --allow-downgrades $DOWNLOAD_DIR/$DOTNET_PACKAGE_DIR/*
     fi
 }
 


### PR DESCRIPTION
Script failed at two points for me. The first was that `apt install -y` was used without `--allow-downgrades`. The next was:

`N: Download is performed unsandboxed as root as file '/home/zach/temp/dotnet_packages/dotnet-runtime-deps-5.0.0-rc.1.20451.14-x64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)`

The latter was remedied by running `sudo ./install-dotnet-preview-groovy.sh` instead of switching to root.

Thanks for this! It was the missing link getting pwsh installed!